### PR TITLE
Allow scroll within any element within a page

### DIFF
--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -22,6 +22,7 @@ Released under the MIT License
       loading: null # optional callback when next-page request begins
       success: null # optional callback when next-page request finishes
       error:   null # optional callback when next-page request fails
+      context: window
       state:
         paused:  false
         loading: false
@@ -33,6 +34,7 @@ Released under the MIT License
       @options = $.extend({}, @defaults, options)
       @$container = $(container)
       @$table = $(container).find('table')
+      @$context = $(options.context)
       
       @init()
       
@@ -43,7 +45,7 @@ Released under the MIT License
       scrollTimeout = null
       scrollHandler = (=> @check())
       
-      $(window).scroll ->
+      @$context.scroll ->
         if scrollTimeout
           clearTimeout(scrollTimeout)
           scrollTimeout = null
@@ -60,7 +62,7 @@ Released under the MIT License
       if nav.size() == 0
         @_log "No more pages to load"
       else
-        windowBottom = $(window).scrollTop() + $(window).height()
+        windowBottom = @$context.scrollTop() + @$context.height()
         distance = nav.offset().top - windowBottom
         
         if @options.state.paused


### PR DESCRIPTION
A common use case could be when you are scrolling within a container. By adding a context you are able to use infinite scroll within a content div within a page.
