### PR TITLE
Add support for turbolinks; Allow periodic checks while scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*This branch makes two changes to magoosh's 0.2.0 version: it adds support for turbolinks, and it loads the next page of results while scrolling instead of waiting until scrolling finishes.*
+
 jQuery Infinite Pages
 =====================
 

--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -54,16 +54,15 @@ Released under the MIT License
       scrollDelay = 250
       scrollTimeout = null
       lastCheckAt = null
-      scrollHandler = (=>
+      scrollHandler = =>
         lastCheckAt = +new Date
         @check()
-      )
 
       # Have we waited enough time since the last check?
       shouldCheck = -> +new Date > lastCheckAt + scrollDelay
 
       @$context.scroll ->
-        scrollHandler() if shouldCheck # Call the check once every scrollDelay ms
+        scrollHandler() if shouldCheck() # Call check once every scrollDelay ms
         if scrollTimeout
           clearTimeout(scrollTimeout)
           scrollTimeout = null

--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -13,6 +13,13 @@ Released under the MIT License
 (($, window) ->
   # Define the plugin class
   class InfinitePages
+    # Internal id to tracking the elements used for multiple instances
+    @_ID: 0
+
+    # Internal helper to return a unique id for a new instance for the page
+    @_nextId: ->
+      @_ID += 1
+      @_ID
 
     # Default settings
     defaults:
@@ -35,6 +42,9 @@ Released under the MIT License
       @$container = $(container)
       @$table = $(container).find('table')
       @$context = $(@options.context)
+      @instanceId = @constructor._nextId()
+      @invalidateAt = +new Date # timestamp before which we ignore responses
+      @requestAts = [] # list of timestamps for pending requests
       @init()
 
     # Setup and bind to related events
@@ -49,6 +59,14 @@ Released under the MIT License
           clearTimeout(scrollTimeout)
           scrollTimeout = null
         scrollTimeout = setTimeout(scrollHandler, 250)
+
+      # Set a data attribute so we can find again after a turbolink page is loaded
+      @$container.attr('data-jquery-infinite-pages-container', @instanceId)
+
+      # Setup callbacks to handle turbolinks page loads
+      $(window.document)
+        .on("page:before-unload", => @_invalidateActiveRequests())
+        .on("page:change", => @_recache())
 
     # Internal helper for logging messages
     _log: (msg) ->
@@ -80,6 +98,7 @@ Released under the MIT License
       else
         @_loading()
 
+        @requestAts.push +new Date # note when this request started
         $.getScript(@$container.find(@options.navSelector).attr('href'))
           .done(=> @_success())
           .fail(=> @_error())
@@ -91,12 +110,17 @@ Released under the MIT License
         @$container.find(@options.navSelector).each(@options.loading)
 
     _success: ->
+      # ignore any requests that started before we last invalidated
+      return if @_isInvalidatedRequest(@requestAts.shift())
+      @_recache()
       @options.state.loading = false
       @_log "New page loaded!"
       if typeof @options.success is 'function'
         @$container.find(@options.navSelector).each(@options.success)
 
     _error: ->
+      # ignore any requests that started before we last invalidated
+      return if @_isInvalidatedRequest(@requestAts.shift())
       @options.state.loading = false
       @_log "Error loading new page :("
       if typeof @options.error is 'function'
@@ -112,6 +136,20 @@ Released under the MIT License
       @options.state.paused = false
       @_log "Scroll checks resumed"
       @check()
+
+    _recache: ->
+      # Recache the element references we use (needed when using turbolinks)
+      @$container = $("[data-jquery-infinite-pages-container=#{@instanceId}]")
+      @$table = @$container.find('table')
+      @$context = $(@options.context)
+
+    _invalidateActiveRequests: ->
+      # Invalidate any active requests (needed when using turbolinks)
+      @invalidateAt = +new Date
+
+    _isInvalidatedRequest: (requestAt) ->
+      # Check to see if a request was invalidated
+      requestAt < @invalidateAt
 
   # Define the plugin
   $.fn.extend infinitePages: (option, args...) ->

--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -85,7 +85,6 @@ Released under the MIT License
         @_loading()
 
         $container = @$container
-        @requestAts.push +new Date # note when this request started
         $.getScript(@$container.find(@options.navSelector).attr('href'))
           .done(=> @_success($container))
           .fail(=> @_error($container))

--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -51,14 +51,23 @@ Released under the MIT License
     init: ->
 
       # Debounce scroll event to improve performance
+      scrollDelay = 250
       scrollTimeout = null
-      scrollHandler = (=> @check())
+      lastCheckAt = null
+      scrollHandler = (=>
+        lastCheckAt = +new Date
+        @check()
+      )
+
+      # Have we waited enough time since the last check?
+      shouldCheck = -> +new Date > lastCheckAt + scrollDelay
 
       @$context.scroll ->
+        scrollHandler() if shouldCheck # Call the check once every scrollDelay ms
         if scrollTimeout
           clearTimeout(scrollTimeout)
           scrollTimeout = null
-        scrollTimeout = setTimeout(scrollHandler, 250)
+        scrollTimeout = setTimeout(scrollHandler, scrollDelay)
 
       # Set a data attribute so we can find again after a turbolink page is loaded
       @$container.attr('data-jquery-infinite-pages-container', @instanceId)

--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -41,7 +41,7 @@ Released under the MIT License
       @$container = $(container)
       @$table = $(container).find('table')
       @$context = $(@options.context)
-      @instanceId = @constructor._nextId()
+      @instanceId = @constructor._nextInstanceId()
       @init()
 
     # Setup and bind to related events


### PR DESCRIPTION
For turbolinks, this does two main things:
- element references are recached after next-page results are loaded
- any requests initiated before a turbolinks pageload are ignored if they complete after the results are loaded.

For periodic checks while scrolling: the previous implementation would wait until scrolling stopped to check and potentially load the next page results. This change allows for checks to occur (periodically, at the scrollDelay frequency) so that results can be loaded while scrolling is still happening.
