### PR TITLE
Unbind scroll event when reinstantiated

### DIFF
--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -44,6 +44,7 @@ Released under the MIT License
       scrollTimeout = null
       scrollHandler = (=> @check())
 
+      @$context.unbind('scroll')
       @$context.scroll ->
         if scrollTimeout
           clearTimeout(scrollTimeout)


### PR DESCRIPTION
There was a bug when `elem.infinitePages()` was called on a second element - the `window.scroll` was not unbound and so links generated still came from the old context/container.

In most cases, this one-line change fixes the turbolinks issues people are experiencing in #5. Just remember to reinstantiate infinitePages whenever turbolinks changes the page. For example (in my app):

``` ruby
ready = ->
  # Configure infinite table
  $('.infinite-table').infinitePages
    loading: ->
      $(this).text('Loading next page...')
    error: ->
      $(this).button('There was an error, please try again')
$(document).ready(ready)
$(document).on('turbolinks:load', ready)
```
