### PR TITLE
Adding ability to unbind scroll handler and destroy plugin object

### DIFF
--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -44,7 +44,8 @@ Released under the MIT License
       scrollTimeout = null
       scrollHandler = (=> @check())
 
-      @$context.scroll ->
+      # Use namespace to let us unbind event handler
+      @$context.on 'scroll.infinitePages', ->
         if scrollTimeout
           clearTimeout(scrollTimeout)
           scrollTimeout = null
@@ -113,6 +114,11 @@ Released under the MIT License
       @_log "Scroll checks resumed"
       @check()
 
+    # Stop event handling
+    stop: ->
+      @$context.off 'scroll.infinitePages'
+      @_log "Scroll checks stopped"
+
   # Define the plugin
   $.fn.extend infinitePages: (option, args...) ->
     @each ->
@@ -122,6 +128,10 @@ Released under the MIT License
       if !data
         $this.data 'infinitepages', (data = new InfinitePages(this, option))
       if typeof option == 'string'
-        data[option].apply(data, args)
+        if option == 'destroy'
+          data.stop args
+          $this.removeData 'infinitepages'
+        else
+          data[option].apply(data, args)
 
 ) window.jQuery, window


### PR DESCRIPTION
Hi!

As i can see there was no ways to destroy plugin. So if somebody uses, for instance turbolinks (issue #5), he faces with problem, when infinity pages from old page still working in the new one.

So i think, it can be useful to get ability to destroy plugin.

Example of usage:

``` coffeescript
# Bind plugin on page load
$(document).on "turbolinks:load", ->
  $(someElement).infinitePages settings

# Destroy plugin when user leaves the page
$(document).on 'turbolinks:visit', ->
  $(someElement).infinitePages 'destroy'
```
