### PR TITLE
replace .size() with .length

### DIFF
--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -58,7 +58,7 @@ Released under the MIT License
     # load event if close enough
     check: ->
       nav = @$container.find(@options.navSelector)
-      if nav.size() == 0
+      if nav.length == 0
         @_log "No more pages to load"
       else
         windowBottom = @$context.scrollTop() + @$context.height()

--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -58,7 +58,7 @@ Released under the MIT License
     # load event if close enough
     check: ->
       nav = @$container.find(@options.navSelector)
-      if (typeof nav.size == 'function' ? nav.size() : nav.length) == 0
+      if (if typeof nav.size == 'function' then nav.size() else nav.length) == 0
         @_log "No more pages to load"
       else
         windowBottom = @$context.scrollTop() + @$context.height()

--- a/app/assets/javascripts/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/jquery.infinite-pages.js.coffee
@@ -58,7 +58,7 @@ Released under the MIT License
     # load event if close enough
     check: ->
       nav = @$container.find(@options.navSelector)
-      if nav.length == 0
+      if (typeof nav.size == 'function' ? nav.size() : nav.length) == 0
         @_log "No more pages to load"
       else
         windowBottom = @$context.scrollTop() + @$context.height()


### PR DESCRIPTION
“The .size() method is deprecated as of jQuery 1.8. Use the .length property instead.”
https://api.jquery.com/size/
